### PR TITLE
Implemented aircraft type display

### DIFF
--- a/main/SetupMenu.cpp
+++ b/main/SetupMenu.cpp
@@ -353,6 +353,12 @@ void SetupMenu::options_menu_create_settings( MenuEntry *top ){
 	top->addEntry( mod );
 	mod->setHelp( "Normal mode for multiple targets, Simple mode only one", hpos );
 
+	SetupMenuSelect * aid = new SetupMenuSelect( "Aircraft ID", RST_NONE, 0, true, &aircraft_id );
+	aid->addEntry( "Registration and CN");
+	aid->addEntry( "Aircraft Type and CN");
+	top->addEntry( aid );
+	aid->setHelp( "Select whether to display registration or aircraft type with CN", hpos );
+
 	SetupMenuSelect * log = new SetupMenuSelect( "Distance Mode", RST_NONE, 0, true, &log_scale );
 	log->addEntry( "Linear");
 	log->addEntry( "Logarithmic");

--- a/main/SetupNG.cpp
+++ b/main/SetupNG.cpp
@@ -54,6 +54,7 @@ SetupNG<int> 			data_monitor("DATAMON", MON_OFF, RST_NONE, SYNC_NONE, VOLATILE  
 SetupNG<int> 			traffic_demo("TRADEM", 0 );
 SetupNG<int>  			display_orientation("DISPLAY_ORIENT" , DISPLAY_NORMAL );
 SetupNG<int>  			display_mode("DISPLAY_MODE" , DISPLAY_MULTI );
+SetupNG<int>  			aircraft_id("AIRCRAFT_ID" , AIRCRAFT_ID_REG );
 SetupNG<int>  			display_non_moving_target("NON_MOVE" , NON_MOVE_HIDE );
 SetupNG<int>  			notify_near( "NOTFNEAR", BUZZ_2KM );
 SetupNG<int>  			rs232_polarity( "RS232POL", RS232_INVERTED );

--- a/main/SetupNG.h
+++ b/main/SetupNG.h
@@ -49,6 +49,7 @@ typedef enum e_reset { RESET_NO, RESET_YES } e_reset_t;   // determines if data 
 typedef enum e_volatility { VOLATILE, PERSISTENT, SEMI_VOLATILE } e_volatility_t;  // stored in RAM, FLASH, or into FLASH after a while
 typedef enum e_display_orientation { DISPLAY_NORMAL, DISPLAY_TOPDOWN } e_display_orientation_t;
 typedef enum e_display_mode { DISPLAY_MULTI, DISPLAY_SIMPLE } e_display_mode_t;
+typedef enum e_aircraft_id { AIRCRAFT_ID_REG, AIRCRAFT_ID_TYPE } e_display_id_t;
 typedef enum e_unit_type{ UNIT_NONE, UNIT_TEMPERATURE, UNIT_ALT, UNIT_SPEED, UNIT_VARIO, UNIT_QNH } e_unit_type_t;
 typedef enum e_alt_unit { ALT_UNIT_METER, ALT_UNIT_FT, ALT_UNIT_FL } e_alt_unit_t;
 typedef enum e_dst_unit { DST_UNIT_KM, DST_UNIT_FT, DST_UNIT_MILES } e_dst_unit_t;
@@ -337,6 +338,7 @@ extern SetupNG<int> 		data_monitor;
 extern SetupNG<int> 		traffic_demo;
 extern SetupNG<int>  		display_orientation;
 extern SetupNG<int>  		display_mode;
+extern SetupNG<int>  		aircraft_id;
 extern SetupNG<int>  		display_non_moving_target;
 extern SetupNG<int>  		notify_near;
 extern SetupNG<int>  		rs232_polarity;

--- a/main/Target.cpp
+++ b/main/Target.cpp
@@ -11,6 +11,7 @@
 #include "vector.h"
 #include "flarmnetdata.h"
 #include "flarmview.h"
+#include "SetupNG.h"
 #include "TargetManager.h"
 
 extern AdaptUGC *egl;
@@ -49,7 +50,7 @@ Target::Target(nmea_pflaa_s a_pflaa) {
     tek_climb = 0.0; last_groundspeed = pflaa.groundSpeed;
     tick = 0; last_pflaa_time = -1; _buzzedHoldDown = 0;
     dist = prox = 10000.0; recalc();
-    reg = comp = nullptr; age = 0; is_nearest = false; alarm = false; alarm_timer = 0;
+    reg = comp = type = nullptr; age = 0; is_nearest = false; alarm = false; alarm_timer = 0;
     _isPriority = false;
     is_best = false;
     is_nearest = false;
@@ -59,6 +60,7 @@ Target::Target(nmea_pflaa_s a_pflaa) {
         if (pflaa.ID == flarmnet_db[i].id){
             reg = (char*)flarmnet_db[i].reg;
             comp = (char*)flarmnet_db[i].cn;
+            type = (char*)flarmnet_db[i].type;
         }
     }
 
@@ -83,8 +85,8 @@ void Target::drawID(uint8_t r, uint8_t g, uint8_t b){
     egl->setColor(r,g,b);
     egl->setFont(ucg_font_fub20_hf);
     int w = egl->getStrWidth(cur_id);
-    if(w>150){ egl->setFont(ucg_font_fub17_hf); w=egl->getStrWidth(cur_id); }
-    if(w>150){ egl->setFont(ucg_font_fub14_hf); w=egl->getStrWidth(cur_id); }
+    if(w>200){ egl->setFont(ucg_font_fub17_hf); w=egl->getStrWidth(cur_id); }
+    if(w>200){ egl->setFont(ucg_font_fub14_hf); w=egl->getStrWidth(cur_id); }
     egl->setPrintPos((DISPLAY_W-5)-w,DISPLAY_H-7);
     egl->printf("%s",cur_id);
 }
@@ -130,9 +132,13 @@ void Target::drawInfo(bool erase) {
 	if ((old_id != pflaa.ID) || erase) {
 		if (strlen(cur_id)) drawID(COLOR_BLACK);
 		if (!erase) {
-			if (reg) {
-				if (comp) sprintf(cur_id, "%s %s", reg, comp);
-				else      sprintf(cur_id, "%s", reg);
+			const char* ac_id = reg;
+			if ((aircraft_id.get() == AIRCRAFT_ID_TYPE) && type && strlen(type)) {
+				ac_id = type;
+			}
+			if (ac_id && strlen(ac_id)) {
+				if (comp && strlen(comp)) sprintf(cur_id, "%s %s", ac_id, comp);
+				else      sprintf(cur_id, "%s", ac_id);
 			} else {
 				snprintf(cur_id, sizeof( cur_id ), "%06X", pflaa.ID);
 			}

--- a/main/Target.h
+++ b/main/Target.h
@@ -76,6 +76,7 @@ private:
 	int x,y,old_ax, old_ay, old_x0, old_y0, old_x1, old_y1, old_x2, old_y2, old_closest, old_sidelen, old_cirsize, old_cirsizeteam;
 	char * reg;  // registration from flarmnet DB
 	char * comp; // competition ID
+	char * type; // aircraft type/model from flarmnet DB
 
 	bool is_nearest;
 	bool _isPriority; // new: used for draw order priority

--- a/main/flarmnet.h
+++ b/main/flarmnet.h
@@ -5,4 +5,5 @@ typedef const struct s_flarmnet{
 	const uint32_t flarmID;
 	const char*     reg;
 	const char*     comp;
+	const char*     type;
 } t_flarmnet;

--- a/tools/fln2head.py
+++ b/tools/fln2head.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import datetime
 import csv
+import string
 import requests
 import re
-
-import datetime
 
 HEADER = """\
 /*
  * flarmnet_simple.h - automatisch generiert aus OGN + Flarmnet
- * nur DEVICE_ID, REGISTRATION, CN
+ * nur DEVICE_ID, REGISTRATION, CN, TYPE
  */
 #ifndef FLARMNET_SIMPLE_H
 #define FLARMNET_SIMPLE_H
@@ -19,6 +19,7 @@ typedef struct {
     unsigned int id;
     const char *reg;
     const char *cn;
+    const char *type;
 } flarmnet_entry_t;
 
 static const flarmnet_entry_t flarmnet_db[] = {
@@ -51,8 +52,50 @@ def clean_field(field):
     """Entfernt Quotes, Leerzeichen und prüft Inhalt"""
     return field.strip().strip("'").strip('"')
 
-def valid_entry(reg, cn):
+def clean_ac_type(ac_type):
+    """Entfernt Sonderzeichen und kürzt auf 10 Zeichen"""
+    max_len = 10
+
+    ac_type = ac_type.replace("Towplane", "Tow")
+    ac_type = ac_type.replace("Duo Discus", "DuoDiscus")
+
+    if len(ac_type) > max_len:
+        ac_type = ac_type.translate(str.maketrans("", "", string.punctuation)).strip()
+    if len(ac_type) > max_len:
+        ac_type = ac_type.replace("Discus", "Disc")
+        ac_type = ac_type.replace("Ventus", "Vent")
+        ac_type = ac_type.replace("Astir", "Ast")
+        ac_type = ac_type.replace("Jantar", "Jant")
+        ac_type = ac_type.replace("Glasflugel", "Glasfg")
+    if len(ac_type) > max_len:
+        ac_type = ac_type.replace(" ", "")
+
+    return ac_type[:max_len]
+
+def valid_entry(reg, cn, ac_type):
     """Eintrag nur gültig, wenn REG mindestens 4 alphanumerische Zeichen oder CN nicht leer"""
+    
+    ac_types_to_ignore = [
+        "paraglider",
+        "hang",
+        "drone",
+        "dji",
+        "balloon",
+        "parachute",
+        "motorplane",
+        "ultralight",
+        "helicopter",
+        "gyrocopter",
+        "autogyro",
+        "ground",
+        "ufo",
+        "unknown",
+        "other",
+    ]
+
+    if any(a in ac_type.lower() for a in ac_types_to_ignore):
+        return False
+    
     if cn:
         return True
     alpha_count = len(re.findall(r'[A-Za-z0-9]', reg))
@@ -70,10 +113,12 @@ def load_csv_file(file):
             if len(row) < 5:
                 continue
             fid = row[1]
+            ac_type = row[2]
             reg = row[3]
             cn  = row[4]
-            if valid_entry(reg, cn):
-                data[fid] = {"id": fid, "reg": reg, "cn": cn}
+
+            if valid_entry(reg, cn, ac_type):
+                data[fid] = {"id": fid, "reg": reg, "cn": cn, "type": clean_ac_type(ac_type)}
     return data
 
 def main():
@@ -95,7 +140,7 @@ def main():
     sorted_keys = sorted(ogn_data.keys(), key=lambda x: int(x,16))
     for fid in sorted_keys:
         entry = ogn_data[fid]
-        print(f'    {{0x{int(fid,16):06X}, "{entry["reg"]}", "{entry["cn"]}"}},')
+        print(f'    {{0x{int(fid,16):06X}, "{entry["reg"]}", "{entry["cn"]}", "{entry["type"]}"}},')
     print(FOOTER)
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Showing aircraft type instead of its registration** might give more viable tactical information in some situations. This is why the setting "Aircraft ID" was implemented allowing to choose between "aircraft registration + CN" and "aircraft type + CN" as an aircraft ID.

In order to keep `.bin` size within limits, some filtering had to be applied to flarmnet, omitting less relevant records. This also gives some extra free space for future extensions of the database. Some smart aircraft type shortening had to be applied as well, maximising useful information that could be fitted in 10 symbols.

![2026-01-30 17 19 53](https://github.com/user-attachments/assets/14d4f890-4e2d-4e5a-9942-9bb69a8b3c14)
![2026-01-30 17 19 59](https://github.com/user-attachments/assets/fbc90faf-5c7e-4f0c-85d6-f30f5a493ffb)
